### PR TITLE
syntax cleanups

### DIFF
--- a/layouts/partials/sidebar/sidebar.html
+++ b/layouts/partials/sidebar/sidebar.html
@@ -22,4 +22,3 @@
 	</div>
 </div>
 <div class="clearer"></div>
-</div>

--- a/layouts/partials/sidebar/sidebar.html
+++ b/layouts/partials/sidebar/sidebar.html
@@ -5,7 +5,9 @@
 				{{ with .Site.Params.sidebar.logo -}}
 					<img class="logo" src="{{ $.Site.BaseURL }}{{ . }}" alt="Logo"/>
 				{{- end }}
+				{{ with .Site.Params.name -}}
 				<h1 class="logo logo-name">{{ .Site.Params.name }}</h1>
+				{{- end }}
 			</a>
 		</p>
 		


### PR DESCRIPTION
Hi,

these two suggested changes clean up a stray </div> that I believe shold not be there, and it will only render the logo h1 entry if there is actually a name set in the config.toml.
Please consider applying.

Greetings
Marc
